### PR TITLE
Run test for CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ compiler:
     - clang
 script:
     - $CC -O3 test.cpp -o test -lstdc++
+    - ./test --ci && echo "OK"
 
 
 


### PR DESCRIPTION
我看了test的代码，实际上是不会走网络的，只是内存直接收发包，用来验证算法是否正确。
只不过mode0,1,2是需要用户按一个Enter，可以加一个开关，默认是开启这种方式，而在TravisCI中就直接运行，只打印结果，这样可以检测数据是不是在一定范围内。
譬如CI跑这个test时，只打印：
default mode result (29962ms):
avgrtt=5320 maxrtt=10278 tx=326
normal mode result (20256ms):
avgrtt=155 maxrtt=506 tx=1275
fast mode result (20202ms):
avgrtt=139 maxrtt=384 tx=1340
同时判断如果这些数值不在合理的范围内，就应该报错。
如果每次提交代码都会检测这个结果，这样会更合适。

主要改动包括：
1. 添加了一个参数`--ci`，默认忽略这个选项，可以通过它设置ci。
1. 如果是默认方式，和之前一样，没有做改动。用户默认运行test也是和之前一样。
1. 如果是ci方式，不打印详细的信息，只打印结果，同时比较mode0,1,2三个结果，效果应该2>1>0，否则就报错，CI会失败。