### PR TITLE
Fix potential integer overflow memory corruption bug

### DIFF
--- a/ikcp.c
+++ b/ikcp.c
@@ -637,6 +637,13 @@ static void ikcp_ack_push(ikcpcb *kcp, IUINT32 sn, IUINT32 ts)
 		size_t newblock;
 
 		for (newblock = 8; newblock < newsize; newblock <<= 1);
+
+		/* newblock < 2^29 so that malloc doesn't overflow uint32 */
+		if (sizeof(size_t) == 4U && newblock >= 536870912) {
+			assert(0);
+			abort();
+		}
+
 		acklist = (IUINT32*)ikcp_malloc(newblock * sizeof(IUINT32) * 2);
 
 		if (acklist == NULL) {


### PR DESCRIPTION
发现了一个整形溢出bug，当然我不熟悉这个项目，不知道有没有危害。我的感觉是只影响32位程序，且需要调用ikcp_ack_push()函数2^28+1次（5亿多次）。但是我觉得最好还是修复掉。在malloc里做乘法是经典的整形溢出漏洞。

commit message in English:
The problem is in function ikcp_ack_push(). If `newsize` is 2^28+1, then `newblock` is 2^29 after the for loop. Then `newblock * sizeof(IUINT32) * 2` is 2^32. If `size_t` is 32-bit unsigned integer (e.g. when compiled for x86), it's actually zero. Note that malloc(0) may return a valid pointer, and it's assigned to `acklist`. Later when you copy `kcp->acklist` to `acklist`, you corrupt the memory, because a `malloc(0)` pointer shouldn't be dereferenced.