### PR TITLE
Ensure aligned memory accesses on little endian machines

### DIFF
--- a/ikcp.c
+++ b/ikcp.c
@@ -70,7 +70,8 @@ static inline char *ikcp_encode16u(char *p, unsigned short w)
 	*(unsigned char*)(p + 0) = (w & 255);
 	*(unsigned char*)(p + 1) = (w >> 8);
 #else
-	*(unsigned short*)(p) = w;
+	*(unsigned char*)(p + 0) = (w >> 8);
+	*(unsigned char*)(p + 1) = (w & 255);
 #endif
 	p += 2;
 	return p;
@@ -83,7 +84,8 @@ static inline const char *ikcp_decode16u(const char *p, unsigned short *w)
 	*w = *(const unsigned char*)(p + 1);
 	*w = *(const unsigned char*)(p + 0) + (*w << 8);
 #else
-	*w = *(const unsigned short*)p;
+	*w = *(const unsigned char*)(p + 0);
+	*w = *(const unsigned char*)(p + 1) + (*w << 8);
 #endif
 	p += 2;
 	return p;
@@ -98,7 +100,10 @@ static inline char *ikcp_encode32u(char *p, IUINT32 l)
 	*(unsigned char*)(p + 2) = (unsigned char)((l >> 16) & 0xff);
 	*(unsigned char*)(p + 3) = (unsigned char)((l >> 24) & 0xff);
 #else
-	*(IUINT32*)p = l;
+    *(unsigned char*)(p + 0) = (unsigned char)((l >> 24) & 0xff);
+    *(unsigned char*)(p + 1) = (unsigned char)((l >> 16) & 0xff);
+    *(unsigned char*)(p + 2) = (unsigned char)((l >>  8) & 0xff);
+    *(unsigned char*)(p + 3) = (unsigned char)((l >>  0) & 0xff);
 #endif
 	p += 4;
 	return p;
@@ -112,8 +117,11 @@ static inline const char *ikcp_decode32u(const char *p, IUINT32 *l)
 	*l = *(const unsigned char*)(p + 2) + (*l << 8);
 	*l = *(const unsigned char*)(p + 1) + (*l << 8);
 	*l = *(const unsigned char*)(p + 0) + (*l << 8);
-#else 
-	*l = *(const IUINT32*)p;
+#else
+	*l = *(const unsigned char*)(p + 0);
+	*l = *(const unsigned char*)(p + 1) + (*l << 8);
+	*l = *(const unsigned char*)(p + 2) + (*l << 8);
+	*l = *(const unsigned char*)(p + 3) + (*l << 8);
 #endif
 	p += 4;
 	return p;


### PR DESCRIPTION
In the current implementation, `p` must be aligned in order to avoid undefined behavior. This change ensures that kcp can run on armv7 (and similar alignment sensitive architectures) even when a high level of optimization is used.