### PR TITLE
improve CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,31 @@
-PROJECT(kcp)
 CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+
+project(kcp LANGUAGES C)
+
+include(CTest)
+include(GNUInstallDirs)
 
 add_library(kcp STATIC ikcp.c)
 
-add_executable(kcp_test test.cpp)
+install(FILES ikcp.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
+install(TARGETS kcp
+    EXPORT kcp-targets
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
 
+install(EXPORT kcp-targets
+    FILE kcp-config.cmake
+    NAMESPACE kcp::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/kcp
+)
 
-
-
+if (BUILD_TESTING)
+    enable_language(CXX)
+    
+    add_executable(kcp_test test.cpp)
+    if(MSVC AND NOT (MSVC_VERSION LESS 1900))
+        target_compile_options(kcp_test PRIVATE /utf-8)
+    endif()
+endif ()


### PR DESCRIPTION
- add `install` target
   ```
   mkdir build
   cd build
   cmake .. -DCMAKE_INSTALL_PREFIX=./install
   make install
   ```
- add `BUILD_TESTING` option
   This allows the users excluding `kcp_test` target in the configuration step:
   ```
   cmake .. -DBUILD_TESTING=OFF
   ```