### PR TITLE
add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# top-most EditorConfig file
+root = true
+
+# Windows-style newlines with a newline ending every file
+[*]
+end_of_line = crlf
+insert_final_newline = true
+
+[*.{c,cpp,h}]
+charset = utf-8
+indent_style = tab
+
+# Matches the exact files either CMakeLists.txt or .travis.yml
+[{CMakeLists.txt,.travis.yml}]
+charset = utf-8
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Hi! I noticed we have a PR to change the encoding of `test.cpp` to `utf-8` before: https://github.com/skywind3000/kcp/pull/59.
To make life a little easier, we can add a [```EditorConfig```](https://editorconfig.org/) file. Most of today's code editors will respect those settings in `.editorconfig`.