### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -47,6 +47,18 @@ There are two kinds of ARQ model responses: UNA (All packets before this number 
 KCP normal mode uses the same fair concession rules as TCP, i.e., the send window size is determined by: four factors including the size of the send cache, the size of the receive buffer at the receiving end, packet loss concession and slow start. However, when sending small data with high timeliness requirement, it is allowed to select skipping the latter two steps through configuration, and use only the first two items to control the transmission frequency, sacrificing some of the fairness and bandwidth utilization, in exchange for the effect of smooth transmission even when BT is opened.
 
 
+# Quick install
+
+You can download and install kcp using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install kcp
+
+The kcp port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 # Basic Usage
 
 1. Create KCP object:

--- a/README.en.md
+++ b/README.en.md
@@ -47,7 +47,7 @@ There are two kinds of ARQ model responses: UNA (All packets before this number 
 KCP normal mode uses the same fair concession rules as TCP, i.e., the send window size is determined by: four factors including the size of the send cache, the size of the receive buffer at the receiving end, packet loss concession and slow start. However, when sending small data with high timeliness requirement, it is allowed to select skipping the latter two steps through configuration, and use only the first two items to control the transmission frequency, sacrificing some of the fairness and bandwidth utilization, in exchange for the effect of smooth transmission even when BT is opened.
 
 
-# Quick install
+# Quick Install
 
 You can download and install kcp using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ TCP是为流量设计的（每秒内可以传输多少KB的数据），讲究的
    KCP正常模式同TCP一样使用公平退让法则，即发送窗口大小由：发送缓存大小、接收端剩余接收缓存大小、丢包退让及慢启动这四要素决定。但传送及时性要求很高的小数据时，可选择通过配置跳过后两步，仅用前两项来控制发送频率。以牺牲部分公平性及带宽利用率之代价，换取了开着BT都能流畅传输的效果。
 
 
+# 快速安装
+
+您可以使用[vcpkg](https://github.com/Microsoft/vcpkg)库管理器下载并安装kcp:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install kcp
+
+vcpkg中的kcp库由Microsoft团队成员和社区贡献者保持最新状态。如果版本过时，请在vcpkg存储库上[创建问题或请求请求](https://github.com/Microsoft/vcpkg)。
+
 # 基本使用
 
 1. 创建 KCP对象：


### PR DESCRIPTION
kcp is available as a port in vcpkg, a C++ library manager that simplifies installation for kcp and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build kcp, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is [what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/kcp/portfile.cmake). We try to keep the library maintained as close as possible to the original library.

If you have any questions, you can reply to me in Chinese : )