### PR TITLE
同时生成动态库和静态库，安装的时候安装的是动态库

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,13 @@ include(CTest)
 include(GNUInstallDirs)
 
 add_library(kcp STATIC ikcp.c)
+add_library(kcp_shared SHARED ikcp.c)
+
+set_property(TARGET kcp_shared PROPERTY LIBRARY_OUTPUT_NAME kcp)
 
 install(FILES ikcp.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-install(TARGETS kcp
+install(TARGETS kcp_shared
     EXPORT kcp-targets
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}


### PR DESCRIPTION
原因：
1. 在同一个系统中，有多个应用需要集成KCP应用中，我们更倾向于使用动态库。
2. 安装的使用通常都是“动态库”+“头文件”