### PR TITLE
1. 调整日志掩码的表示形式：10进制改为16进制 2. 增加打开所有日志的宏：IKCP_LOG_ALL

### DIFF
--- a/ikcp.h
+++ b/ikcp.h
@@ -2,7 +2,7 @@
 //
 // KCP - A Better ARQ Protocol Implementation
 // skywind3000 (at) gmail.com, 2010-2011
-//  
+//
 // Features:
 // + Average RTT reduce 30% - 40% vs traditional ARQ like tcp.
 // + Maximum RTT reduce three times vs tcp.
@@ -18,40 +18,40 @@
 
 
 //=====================================================================
-// 32BIT INTEGER DEFINITION 
+// 32BIT INTEGER DEFINITION
 //=====================================================================
 #ifndef __INTEGER_32_BITS__
 #define __INTEGER_32_BITS__
-#if defined(_WIN64) || defined(WIN64) || defined(__amd64__) || \
-	defined(__x86_64) || defined(__x86_64__) || defined(_M_IA64) || \
-	defined(_M_AMD64)
-	typedef unsigned int ISTDUINT32;
-	typedef int ISTDINT32;
-#elif defined(_WIN32) || defined(WIN32) || defined(__i386__) || \
-	defined(__i386) || defined(_M_X86)
-	typedef unsigned long ISTDUINT32;
-	typedef long ISTDINT32;
+#if defined(_WIN64) || defined(WIN64) || defined(__amd64__)         \
+    || defined(__x86_64) || defined(__x86_64__) || defined(_M_IA64) \
+    || defined(_M_AMD64)
+typedef unsigned int ISTDUINT32;
+typedef int          ISTDINT32;
+#elif defined(_WIN32) || defined(WIN32) || defined(__i386__) \
+    || defined(__i386) || defined(_M_X86)
+typedef unsigned long      ISTDUINT32;
+typedef long               ISTDINT32;
 #elif defined(__MACOS__)
-	typedef UInt32 ISTDUINT32;
-	typedef SInt32 ISTDINT32;
+typedef UInt32 ISTDUINT32;
+typedef SInt32 ISTDINT32;
 #elif defined(__APPLE__) && defined(__MACH__)
-	#include <sys/types.h>
-	typedef u_int32_t ISTDUINT32;
-	typedef int32_t ISTDINT32;
+#include <sys/types.h>
+typedef u_int32_t ISTDUINT32;
+typedef int32_t   ISTDINT32;
 #elif defined(__BEOS__)
-	#include <sys/inttypes.h>
-	typedef u_int32_t ISTDUINT32;
-	typedef int32_t ISTDINT32;
+#include <sys/inttypes.h>
+typedef u_int32_t ISTDUINT32;
+typedef int32_t   ISTDINT32;
 #elif (defined(_MSC_VER) || defined(__BORLANDC__)) && (!defined(__MSDOS__))
-	typedef unsigned __int32 ISTDUINT32;
-	typedef __int32 ISTDINT32;
+typedef unsigned __int32 ISTDUINT32;
+typedef __int32          ISTDINT32;
 #elif defined(__GNUC__)
-	#include <stdint.h>
-	typedef uint32_t ISTDUINT32;
-	typedef int32_t ISTDINT32;
-#else 
-	typedef unsigned long ISTDUINT32; 
-	typedef long ISTDINT32;
+#include <stdint.h>
+typedef uint32_t ISTDUINT32;
+typedef int32_t  ISTDINT32;
+#else
+typedef unsigned long ISTDUINT32;
+typedef long          ISTDINT32;
 #endif
 #endif
 
@@ -94,7 +94,7 @@ typedef ISTDUINT32 IUINT32;
 #if defined(_MSC_VER) || defined(__BORLANDC__)
 typedef __int64 IINT64;
 #else
-typedef long long IINT64;
+typedef long long          IINT64;
 #endif
 #endif
 
@@ -111,15 +111,15 @@ typedef unsigned long long IUINT64;
 #if defined(__GNUC__)
 
 #if (__GNUC__ > 3) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 1))
-#define INLINE         __inline__ __attribute__((always_inline))
+#define INLINE __inline__ __attribute__((always_inline))
 #else
-#define INLINE         __inline__
+#define INLINE __inline__
 #endif
 
 #elif (defined(_MSC_VER) || defined(__BORLANDC__) || defined(__WATCOMC__))
 #define INLINE __inline
 #else
-#define INLINE 
+#define INLINE
 #endif
 #endif
 
@@ -129,96 +129,111 @@ typedef unsigned long long IUINT64;
 
 
 //=====================================================================
-// QUEUE DEFINITION                                                  
+// QUEUE DEFINITION
 //=====================================================================
 #ifndef __IQUEUE_DEF__
 #define __IQUEUE_DEF__
 
-struct IQUEUEHEAD {
-	struct IQUEUEHEAD *next, *prev;
+struct IQUEUEHEAD
+{
+    struct IQUEUEHEAD *next, *prev;
 };
 
 typedef struct IQUEUEHEAD iqueue_head;
 
 
 //---------------------------------------------------------------------
-// queue init                                                         
+// queue init
 //---------------------------------------------------------------------
-#define IQUEUE_HEAD_INIT(name) { &(name), &(name) }
-#define IQUEUE_HEAD(name) \
-	struct IQUEUEHEAD name = IQUEUE_HEAD_INIT(name)
+#define IQUEUE_HEAD_INIT(name) \
+    {                          \
+        &(name), &(name)       \
+    }
+#define IQUEUE_HEAD(name) struct IQUEUEHEAD name = IQUEUE_HEAD_INIT(name)
 
-#define IQUEUE_INIT(ptr) ( \
-	(ptr)->next = (ptr), (ptr)->prev = (ptr))
+#define IQUEUE_INIT(ptr) ((ptr)->next = (ptr), (ptr)->prev = (ptr))
 
-#define IOFFSETOF(TYPE, MEMBER) ((size_t) &((TYPE *)0)->MEMBER)
+#define IOFFSETOF(TYPE, MEMBER) ((size_t) & ((TYPE *)0)->MEMBER)
 
-#define ICONTAINEROF(ptr, type, member) ( \
-		(type*)( ((char*)((type*)ptr)) - IOFFSETOF(type, member)) )
+#define ICONTAINEROF(ptr, type, member) \
+    ((type *)(((char *)((type *)ptr)) - IOFFSETOF(type, member)))
 
 #define IQUEUE_ENTRY(ptr, type, member) ICONTAINEROF(ptr, type, member)
 
 
 //---------------------------------------------------------------------
-// queue operation                     
+// queue operation
 //---------------------------------------------------------------------
-#define IQUEUE_ADD(node, head) ( \
-	(node)->prev = (head), (node)->next = (head)->next, \
-	(head)->next->prev = (node), (head)->next = (node))
+#define IQUEUE_ADD(node, head)                           \
+    ((node)->prev = (head), (node)->next = (head)->next, \
+     (head)->next->prev = (node), (head)->next = (node))
 
-#define IQUEUE_ADD_TAIL(node, head) ( \
-	(node)->prev = (head)->prev, (node)->next = (head), \
-	(head)->prev->next = (node), (head)->prev = (node))
+#define IQUEUE_ADD_TAIL(node, head)                      \
+    ((node)->prev = (head)->prev, (node)->next = (head), \
+     (head)->prev->next = (node), (head)->prev = (node))
 
 #define IQUEUE_DEL_BETWEEN(p, n) ((n)->prev = (p), (p)->next = (n))
 
-#define IQUEUE_DEL(entry) (\
-	(entry)->next->prev = (entry)->prev, \
-	(entry)->prev->next = (entry)->next, \
-	(entry)->next = 0, (entry)->prev = 0)
+#define IQUEUE_DEL(entry)                                                      \
+    ((entry)->next->prev = (entry)->prev, (entry)->prev->next = (entry)->next, \
+     (entry)->next = 0, (entry)->prev = 0)
 
-#define IQUEUE_DEL_INIT(entry) do { \
-	IQUEUE_DEL(entry); IQUEUE_INIT(entry); } while (0)
+#define IQUEUE_DEL_INIT(entry) \
+    do                         \
+    {                          \
+        IQUEUE_DEL(entry);     \
+        IQUEUE_INIT(entry);    \
+    } while (0)
 
 #define IQUEUE_IS_EMPTY(entry) ((entry) == (entry)->next)
 
-#define iqueue_init		IQUEUE_INIT
-#define iqueue_entry	IQUEUE_ENTRY
-#define iqueue_add		IQUEUE_ADD
-#define iqueue_add_tail	IQUEUE_ADD_TAIL
-#define iqueue_del		IQUEUE_DEL
-#define iqueue_del_init	IQUEUE_DEL_INIT
+#define iqueue_init     IQUEUE_INIT
+#define iqueue_entry    IQUEUE_ENTRY
+#define iqueue_add      IQUEUE_ADD
+#define iqueue_add_tail IQUEUE_ADD_TAIL
+#define iqueue_del      IQUEUE_DEL
+#define iqueue_del_init IQUEUE_DEL_INIT
 #define iqueue_is_empty IQUEUE_IS_EMPTY
 
-#define IQUEUE_FOREACH(iterator, head, TYPE, MEMBER) \
-	for ((iterator) = iqueue_entry((head)->next, TYPE, MEMBER); \
-		&((iterator)->MEMBER) != (head); \
-		(iterator) = iqueue_entry((iterator)->MEMBER.next, TYPE, MEMBER))
+#define IQUEUE_FOREACH(iterator, head, TYPE, MEMBER)            \
+    for ((iterator) = iqueue_entry((head)->next, TYPE, MEMBER); \
+         &((iterator)->MEMBER) != (head);                       \
+         (iterator) = iqueue_entry((iterator)->MEMBER.next, TYPE, MEMBER))
 
 #define iqueue_foreach(iterator, head, TYPE, MEMBER) \
-	IQUEUE_FOREACH(iterator, head, TYPE, MEMBER)
+    IQUEUE_FOREACH(iterator, head, TYPE, MEMBER)
 
 #define iqueue_foreach_entry(pos, head) \
-	for( (pos) = (head)->next; (pos) != (head) ; (pos) = (pos)->next )
-	
+    for ((pos) = (head)->next; (pos) != (head); (pos) = (pos)->next)
 
-#define __iqueue_splice(list, head) do {	\
-		iqueue_head *first = (list)->next, *last = (list)->prev; \
-		iqueue_head *at = (head)->next; \
-		(first)->prev = (head), (head)->next = (first);		\
-		(last)->next = (at), (at)->prev = (last); }	while (0)
 
-#define iqueue_splice(list, head) do { \
-	if (!iqueue_is_empty(list)) __iqueue_splice(list, head); } while (0)
+#define __iqueue_splice(list, head)                              \
+    do                                                           \
+    {                                                            \
+        iqueue_head *first = (list)->next, *last = (list)->prev; \
+        iqueue_head *at = (head)->next;                          \
+        (first)->prev = (head), (head)->next = (first);          \
+        (last)->next = (at), (at)->prev = (last);                \
+    } while (0)
 
-#define iqueue_splice_init(list, head) do {	\
-	iqueue_splice(list, head);	iqueue_init(list); } while (0)
+#define iqueue_splice(list, head)                                \
+    do                                                           \
+    {                                                            \
+        if (!iqueue_is_empty(list)) __iqueue_splice(list, head); \
+    } while (0)
+
+#define iqueue_splice_init(list, head) \
+    do                                 \
+    {                                  \
+        iqueue_splice(list, head);     \
+        iqueue_init(list);             \
+    } while (0)
 
 
 #ifdef _MSC_VER
-#pragma warning(disable:4311)
-#pragma warning(disable:4312)
-#pragma warning(disable:4996)
+#pragma warning(disable : 4311)
+#pragma warning(disable : 4312)
+#pragma warning(disable : 4996)
 #endif
 
 #endif
@@ -228,36 +243,35 @@ typedef struct IQUEUEHEAD iqueue_head;
 // BYTE ORDER & ALIGNMENT
 //---------------------------------------------------------------------
 #ifndef IWORDS_BIG_ENDIAN
-    #ifdef _BIG_ENDIAN_
-        #if _BIG_ENDIAN_
-            #define IWORDS_BIG_ENDIAN 1
-        #endif
-    #endif
-    #ifndef IWORDS_BIG_ENDIAN
-        #if defined(__hppa__) || \
-            defined(__m68k__) || defined(mc68000) || defined(_M_M68K) || \
-            (defined(__MIPS__) && defined(__MIPSEB__)) || \
-            defined(__ppc__) || defined(__POWERPC__) || defined(_M_PPC) || \
-            defined(__sparc__) || defined(__powerpc__) || \
-            defined(__mc68000__) || defined(__s390x__) || defined(__s390__)
-            #define IWORDS_BIG_ENDIAN 1
-        #endif
-    #endif
-    #ifndef IWORDS_BIG_ENDIAN
-        #define IWORDS_BIG_ENDIAN  0
-    #endif
+#ifdef _BIG_ENDIAN_
+#if _BIG_ENDIAN_
+#define IWORDS_BIG_ENDIAN 1
+#endif
+#endif
+#ifndef IWORDS_BIG_ENDIAN
+#if defined(__hppa__) || defined(__m68k__) || defined(mc68000)            \
+    || defined(_M_M68K) || (defined(__MIPS__) && defined(__MIPSEB__))     \
+    || defined(__ppc__) || defined(__POWERPC__) || defined(_M_PPC)        \
+    || defined(__sparc__) || defined(__powerpc__) || defined(__mc68000__) \
+    || defined(__s390x__) || defined(__s390__)
+#define IWORDS_BIG_ENDIAN 1
+#endif
+#endif
+#ifndef IWORDS_BIG_ENDIAN
+#define IWORDS_BIG_ENDIAN 0
+#endif
 #endif
 
 #ifndef IWORDS_MUST_ALIGN
-	#if defined(__i386__) || defined(__i386) || defined(_i386_)
-		#define IWORDS_MUST_ALIGN 0
-	#elif defined(_M_IX86) || defined(_X86_) || defined(__x86_64__)
-		#define IWORDS_MUST_ALIGN 0
-	#elif defined(__amd64) || defined(__amd64__)
-		#define IWORDS_MUST_ALIGN 0
-	#else
-		#define IWORDS_MUST_ALIGN 1
-	#endif
+#if defined(__i386__) || defined(__i386) || defined(_i386_)
+#define IWORDS_MUST_ALIGN 0
+#elif defined(_M_IX86) || defined(_X86_) || defined(__x86_64__)
+#define IWORDS_MUST_ALIGN 0
+#elif defined(__amd64) || defined(__amd64__)
+#define IWORDS_MUST_ALIGN 0
+#else
+#define IWORDS_MUST_ALIGN 1
+#endif
 #endif
 
 
@@ -266,20 +280,20 @@ typedef struct IQUEUEHEAD iqueue_head;
 //=====================================================================
 struct IKCPSEG
 {
-	struct IQUEUEHEAD node;
-	IUINT32 conv;
-	IUINT32 cmd;
-	IUINT32 frg;
-	IUINT32 wnd;
-	IUINT32 ts;
-	IUINT32 sn;
-	IUINT32 una;
-	IUINT32 len;
-	IUINT32 resendts;
-	IUINT32 rto;
-	IUINT32 fastack;
-	IUINT32 xmit;
-	char data[1];
+    struct IQUEUEHEAD node;
+    IUINT32           conv;
+    IUINT32           cmd;
+    IUINT32           frg;
+    IUINT32           wnd;
+    IUINT32           ts;
+    IUINT32           sn;
+    IUINT32           una;
+    IUINT32           len;
+    IUINT32           resendts;
+    IUINT32           rto;
+    IUINT32           fastack;
+    IUINT32           xmit;
+    char              data[1];
 };
 
 
@@ -288,123 +302,130 @@ struct IKCPSEG
 //---------------------------------------------------------------------
 struct IKCPCB
 {
-	IUINT32 conv, mtu, mss, state;
-	IUINT32 snd_una, snd_nxt, rcv_nxt;
-	IUINT32 ts_recent, ts_lastack, ssthresh;
-	IINT32 rx_rttval, rx_srtt, rx_rto, rx_minrto;
-	IUINT32 snd_wnd, rcv_wnd, rmt_wnd, cwnd, probe;
-	IUINT32 current, interval, ts_flush, xmit;
-	IUINT32 nrcv_buf, nsnd_buf;
-	IUINT32 nrcv_que, nsnd_que;
-	IUINT32 nodelay, updated;
-	IUINT32 ts_probe, probe_wait;
-	IUINT32 dead_link, incr;
-	struct IQUEUEHEAD snd_queue;
-	struct IQUEUEHEAD rcv_queue;
-	struct IQUEUEHEAD snd_buf;
-	struct IQUEUEHEAD rcv_buf;
-	IUINT32 *acklist;
-	IUINT32 ackcount;
-	IUINT32 ackblock;
-	void *user;
-	char *buffer;
-	int fastresend;
-	int fastlimit;
-	int nocwnd, stream;
-	int logmask;
-	int (*output)(const char *buf, int len, struct IKCPCB *kcp, void *user);
-	void (*writelog)(const char *log, struct IKCPCB *kcp, void *user);
+    IUINT32           conv, mtu, mss, state;
+    IUINT32           snd_una, snd_nxt, rcv_nxt;
+    IUINT32           ts_recent, ts_lastack, ssthresh;
+    IINT32            rx_rttval, rx_srtt, rx_rto, rx_minrto;
+    IUINT32           snd_wnd, rcv_wnd, rmt_wnd, cwnd, probe;
+    IUINT32           current, interval, ts_flush, xmit;
+    IUINT32           nrcv_buf, nsnd_buf;
+    IUINT32           nrcv_que, nsnd_que;
+    IUINT32           nodelay, updated;
+    IUINT32           ts_probe, probe_wait;
+    IUINT32           dead_link, incr;
+    struct IQUEUEHEAD snd_queue;
+    struct IQUEUEHEAD rcv_queue;
+    struct IQUEUEHEAD snd_buf;
+    struct IQUEUEHEAD rcv_buf;
+    IUINT32          *acklist;
+    IUINT32           ackcount;
+    IUINT32           ackblock;
+    void             *user;
+    char             *buffer;
+    int               fastresend;
+    int               fastlimit;
+    int               nocwnd, stream;
+    int               logmask;
+    int (*output)(const char *buf, int len, struct IKCPCB *kcp, void *user);
+    void (*writelog)(const char *log, struct IKCPCB *kcp, void *user);
 };
 
 
 typedef struct IKCPCB ikcpcb;
 
-#define IKCP_LOG_OUTPUT			1
-#define IKCP_LOG_INPUT			2
-#define IKCP_LOG_SEND			4
-#define IKCP_LOG_RECV			8
-#define IKCP_LOG_IN_DATA		16
-#define IKCP_LOG_IN_ACK			32
-#define IKCP_LOG_IN_PROBE		64
-#define IKCP_LOG_IN_WINS		128
-#define IKCP_LOG_OUT_DATA		256
-#define IKCP_LOG_OUT_ACK		512
-#define IKCP_LOG_OUT_PROBE		1024
-#define IKCP_LOG_OUT_WINS		2048
+#define IKCP_LOG_OUTPUT    0x000001
+#define IKCP_LOG_INPUT     0x000002
+#define IKCP_LOG_SEND      0x000004
+#define IKCP_LOG_RECV      0x000008
+#define IKCP_LOG_IN_DATA   0x000010
+#define IKCP_LOG_IN_ACK    0x000020
+#define IKCP_LOG_IN_PROBE  0x000040
+#define IKCP_LOG_IN_WINS   0x000080
+#define IKCP_LOG_OUT_DATA  0x000100
+#define IKCP_LOG_OUT_ACK   0x000200
+#define IKCP_LOG_OUT_PROBE 0x000400
+#define IKCP_LOG_OUT_WINS  0x000800
+#define IKCP_LOG_ALL                                                  \
+    (IKCP_LOG_OUTPUT | IKCP_LOG_INPUT | IKCP_LOG_SEND | IKCP_LOG_RECV \
+     | IKCP_LOG_IN_DATA | IKCP_LOG_IN_ACK | IKCP_LOG_IN_PROBE         \
+     | IKCP_LOG_IN_WINS | IKCP_LOG_OUT_DATA | IKCP_LOG_OUT_ACK        \
+     | IKCP_LOG_OUT_PROBE | IKCP_LOG_OUT_WINS)
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-//---------------------------------------------------------------------
-// interface
-//---------------------------------------------------------------------
+    //---------------------------------------------------------------------
+    // interface
+    //---------------------------------------------------------------------
 
-// create a new kcp control object, 'conv' must equal in two endpoint
-// from the same connection. 'user' will be passed to the output callback
-// output callback can be setup like this: 'kcp->output = my_udp_output'
-ikcpcb* ikcp_create(IUINT32 conv, void *user);
+    // create a new kcp control object, 'conv' must equal in two endpoint
+    // from the same connection. 'user' will be passed to the output callback
+    // output callback can be setup like this: 'kcp->output = my_udp_output'
+    ikcpcb *ikcp_create(IUINT32 conv, void *user);
 
-// release kcp control object
-void ikcp_release(ikcpcb *kcp);
+    // release kcp control object
+    void ikcp_release(ikcpcb *kcp);
 
-// set output callback, which will be invoked by kcp
-void ikcp_setoutput(ikcpcb *kcp, int (*output)(const char *buf, int len, 
-	ikcpcb *kcp, void *user));
+    // set output callback, which will be invoked by kcp
+    void ikcp_setoutput(ikcpcb *kcp, int (*output)(const char *buf, int len,
+                                                   ikcpcb *kcp, void *user));
 
-// user/upper level recv: returns size, returns below zero for EAGAIN
-int ikcp_recv(ikcpcb *kcp, char *buffer, int len);
+    // user/upper level recv: returns size, returns below zero for EAGAIN
+    int ikcp_recv(ikcpcb *kcp, char *buffer, int len);
 
-// user/upper level send, returns below zero for error
-int ikcp_send(ikcpcb *kcp, const char *buffer, int len);
+    // user/upper level send, returns below zero for error
+    int ikcp_send(ikcpcb *kcp, const char *buffer, int len);
 
-// update state (call it repeatedly, every 10ms-100ms), or you can ask 
-// ikcp_check when to call it again (without ikcp_input/_send calling).
-// 'current' - current timestamp in millisec. 
-void ikcp_update(ikcpcb *kcp, IUINT32 current);
+    // update state (call it repeatedly, every 10ms-100ms), or you can ask
+    // ikcp_check when to call it again (without ikcp_input/_send calling).
+    // 'current' - current timestamp in millisec.
+    void ikcp_update(ikcpcb *kcp, IUINT32 current);
 
-// Determine when should you invoke ikcp_update:
-// returns when you should invoke ikcp_update in millisec, if there 
-// is no ikcp_input/_send calling. you can call ikcp_update in that
-// time, instead of call update repeatly.
-// Important to reduce unnacessary ikcp_update invoking. use it to 
-// schedule ikcp_update (eg. implementing an epoll-like mechanism, 
-// or optimize ikcp_update when handling massive kcp connections)
-IUINT32 ikcp_check(const ikcpcb *kcp, IUINT32 current);
+    // Determine when should you invoke ikcp_update:
+    // returns when you should invoke ikcp_update in millisec, if there
+    // is no ikcp_input/_send calling. you can call ikcp_update in that
+    // time, instead of call update repeatly.
+    // Important to reduce unnacessary ikcp_update invoking. use it to
+    // schedule ikcp_update (eg. implementing an epoll-like mechanism,
+    // or optimize ikcp_update when handling massive kcp connections)
+    IUINT32 ikcp_check(const ikcpcb *kcp, IUINT32 current);
 
-// when you received a low level packet (eg. UDP packet), call it
-int ikcp_input(ikcpcb *kcp, const char *data, long size);
+    // when you received a low level packet (eg. UDP packet), call it
+    int ikcp_input(ikcpcb *kcp, const char *data, long size);
 
-// flush pending data
-void ikcp_flush(ikcpcb *kcp);
+    // flush pending data
+    void ikcp_flush(ikcpcb *kcp);
 
-// check the size of next message in the recv queue
-int ikcp_peeksize(const ikcpcb *kcp);
+    // check the size of next message in the recv queue
+    int ikcp_peeksize(const ikcpcb *kcp);
 
-// change MTU size, default is 1400
-int ikcp_setmtu(ikcpcb *kcp, int mtu);
+    // change MTU size, default is 1400
+    int ikcp_setmtu(ikcpcb *kcp, int mtu);
 
-// set maximum window size: sndwnd=32, rcvwnd=32 by default
-int ikcp_wndsize(ikcpcb *kcp, int sndwnd, int rcvwnd);
+    // set maximum window size: sndwnd=32, rcvwnd=32 by default
+    int ikcp_wndsize(ikcpcb *kcp, int sndwnd, int rcvwnd);
 
-// get how many packet is waiting to be sent
-int ikcp_waitsnd(const ikcpcb *kcp);
+    // get how many packet is waiting to be sent
+    int ikcp_waitsnd(const ikcpcb *kcp);
 
-// fastest: ikcp_nodelay(kcp, 1, 20, 2, 1)
-// nodelay: 0:disable(default), 1:enable
-// interval: internal update timer interval in millisec, default is 100ms 
-// resend: 0:disable fast resend(default), 1:enable fast resend
-// nc: 0:normal congestion control(default), 1:disable congestion control
-int ikcp_nodelay(ikcpcb *kcp, int nodelay, int interval, int resend, int nc);
+    // fastest: ikcp_nodelay(kcp, 1, 20, 2, 1)
+    // nodelay: 0:disable(default), 1:enable
+    // interval: internal update timer interval in millisec, default is 100ms
+    // resend: 0:disable fast resend(default), 1:enable fast resend
+    // nc: 0:normal congestion control(default), 1:disable congestion control
+    int ikcp_nodelay(ikcpcb *kcp, int nodelay, int interval, int resend,
+                     int nc);
 
 
-void ikcp_log(ikcpcb *kcp, int mask, const char *fmt, ...);
+    void ikcp_log(ikcpcb *kcp, int mask, const char *fmt, ...);
 
-// setup allocator
-void ikcp_allocator(void* (*new_malloc)(size_t), void (*new_free)(void*));
+    // setup allocator
+    void ikcp_allocator(void *(*new_malloc)(size_t), void (*new_free)(void *));
 
-// read conv
-IUINT32 ikcp_getconv(const void *ptr);
+    // read conv
+    IUINT32 ikcp_getconv(const void *ptr);
 
 
 #ifdef __cplusplus
@@ -412,5 +433,3 @@ IUINT32 ikcp_getconv(const void *ptr);
 #endif
 
 #endif
-
-

--- a/test_client.c
+++ b/test_client.c
@@ -1,0 +1,183 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <sys/ioctl.h>
+
+#include "test.h"
+#include "ikcp.c"
+
+typedef struct
+{
+    int                socket;
+    struct sockaddr_in server_sa;
+    int                channel;
+} test_ctx_t;
+
+
+int
+kcp_output(const char *buf, int len, ikcpcb *kcp, void *user)
+{
+    test_ctx_t *ctx = (test_ctx_t *)user;
+
+    sendto(ctx->socket, buf, len, 0, (struct sockaddr *)&ctx->server_sa,
+           sizeof(ctx->server_sa));
+
+    return 0;
+}
+
+int
+main(int argc, char **argv)
+{
+    test_ctx_t ctx;
+    char      *server_addr = "127.0.0.1";
+    int        server_port = 50000;
+    int        channel;
+
+    switch (argc)
+    {
+    case 4:
+        server_port = atoi(argv[3]);
+        if (server_port <= 0 || 65535 < server_port)
+        {
+            printf("invalid port: %s\n", argv[3]);
+            return 1;
+        }
+    case 3: server_addr = argv[2];
+    case 2:
+        channel = atoi(argv[1]);
+        if (channel <= 0)
+        {
+            printf("invalid channel number: %s\n", argv[1]);
+            return 1;
+        }
+        break;
+    default:
+        printf("Usage: %s <channel> [server_ip] [server_port]\n", argv[0]);
+        return 1;
+    }
+
+    // init ctx
+    bzero(&ctx, sizeof(ctx));
+
+    ctx.channel = channel;
+
+    ctx.server_sa.sin_family = AF_INET;
+    ctx.server_sa.sin_port   = htons(server_port);
+    if (inet_pton(AF_INET, server_addr, &ctx.server_sa.sin_addr) < 0)
+    {
+        printf("invalid server address: %s\n", server_addr);
+        return 1;
+    }
+
+    // create udp
+    int s = socket(AF_INET, SOCK_DGRAM, 0);
+    if (s == -1) return 1;
+
+    int nb;
+    nb = 1;
+    ioctl(s, FIONBIO, &nb);
+
+    ctx.socket = s;
+
+    ikcpcb *kcp;
+
+    kcp = ikcp_create(ctx.channel, &ctx);
+    if (kcp == NULL) return 1;
+
+    ikcp_setoutput(kcp, kcp_output);
+    ikcp_nodelay(kcp, 1, 1, 2, 1);
+    ikcp_wndsize(kcp, 1024, 1024);
+
+    IUINT32 current = iclock();
+    IUINT32 slap    = current + 20;
+    IUINT32 index   = 0;
+    IUINT32 next    = 0;
+    ssize_t n;
+    char    buffer[65536];
+    IINT64  sumrtt = 0;
+    int     count  = 0;
+    int     maxrtt = 0;
+    IUINT32 ts1    = iclock();
+
+    printf("inited\n");
+
+    while (1)
+    {
+        isleep(1);
+        current = iclock();
+        ikcp_update(kcp, iclock());
+
+        // 每隔 20ms，kcp1发送数据
+        for (; current >= slap; slap += 20)
+        {
+            ((IUINT32 *)buffer)[0] = index++;
+            ((IUINT32 *)buffer)[1] = current;
+
+            // 发送上层协议包
+            ikcp_send(kcp, buffer, 8);
+        }
+
+        // 处理底层数据
+        while (1)
+        {
+            n = recvfrom(s, buffer, sizeof(buffer), 0, NULL, NULL);
+            if (n < 0) break;
+
+            ikcp_input(kcp, buffer, n);
+        }
+
+        // kcp收到应用据
+        while (1)
+        {
+            n = ikcp_recv(kcp, buffer, sizeof(buffer));
+
+            // 没有收到包就退出
+            if (n < 0) break;
+
+            char *p    = buffer;
+            char *last = p + n;
+            while (p + 8 <= last)
+            {
+                IUINT32 sn  = *(IUINT32 *)(p + 0);
+                IUINT32 ts  = *(IUINT32 *)(p + 4);
+                IUINT32 rtt = current - ts;
+
+                if (sn != next)
+                {
+                    // 如果收到的包不连续
+                    printf("ERROR sn %d<->%d\n", (int)count, (int)next);
+                    return 1;
+                }
+
+                p += 8;
+                next++;
+                sumrtt += rtt;
+                count++;
+                if (rtt > (IUINT32)maxrtt) maxrtt = rtt;
+
+                printf("[RECV] sn=%d rtt=%d\n", (int)sn, (int)rtt);
+
+                if (next > 1000) goto done;
+            }
+
+            if (p != last)
+            {
+                // 收到不完整的包
+                printf("receiving a incomplete package\n");
+                return 1;
+            }
+        }
+    }
+
+done:
+
+    ts1 = iclock() - ts1;
+
+    ikcp_release(kcp);
+
+    printf("result (%dms):\n", (int)ts1);
+    printf("avgrtt=%d maxrtt=%d\n", (int)(sumrtt / count), (int)maxrtt);
+
+    return 0;
+}

--- a/test_server.c
+++ b/test_server.c
@@ -1,0 +1,166 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <sys/ioctl.h>
+#include <errno.h>
+
+#include "test.h"
+#include "ikcp.c"
+
+typedef struct
+{
+    int                socket;
+    struct sockaddr_in sa;
+    struct sockaddr_in peer_sa;
+    socklen_t          peer_len;
+    int                channel;
+} test_ctx_t;
+
+
+int
+kcp_output(const char *buf, int len, ikcpcb *kcp, void *user)
+{
+    test_ctx_t *ctx = (test_ctx_t *)user;
+
+
+    ssize_t n = sendto(ctx->socket, buf, len, 0,
+                       (struct sockaddr *)&ctx->peer_sa, sizeof(ctx->peer_sa));
+
+    printf("output: %d/%d bytes\n", n, len);
+
+    return 0;
+}
+
+int
+main(int argc, char **argv)
+{
+    test_ctx_t ctx;
+    char      *listen_addr = "127.0.0.1";
+    int        listen_port = 50001;
+    int        channel;
+
+    switch (argc)
+    {
+    case 4:
+        listen_port = atoi(argv[3]);
+        if (listen_port <= 0 || 65535 < listen_port)
+        {
+            printf("invalid port: %s\n", argv[3]);
+            return 1;
+        }
+    case 3: listen_addr = argv[2];
+    case 2:
+        channel = atoi(argv[1]);
+        if (channel <= 0)
+        {
+            printf("invalid channel number: %s\n", argv[1]);
+            return 1;
+        }
+        break;
+    default:
+        printf("Usage: %s <channel> [listen_ip] [listen_port]\n", argv[0]);
+        return 1;
+    }
+
+    // init ctx
+    bzero(&ctx, sizeof(ctx));
+
+    ctx.channel = channel;
+
+    ctx.sa.sin_family = AF_INET;
+    ctx.sa.sin_port   = htons(listen_port);
+    if (inet_pton(AF_INET, listen_addr, &ctx.sa.sin_addr) < 0)
+    {
+        printf("invalid server address: %s\n", listen_addr);
+        return 1;
+    }
+
+    // create udp
+    int s = socket(AF_INET, SOCK_DGRAM, 0);
+    if (s == -1) return 1;
+
+    if (bind(s, (struct sockaddr *)&ctx.sa, sizeof(ctx.sa)) == -1)
+    {
+        printf("bind failed\n");
+        return 1;
+    }
+
+    int nb;
+    nb = 1;
+    ioctl(s, FIONBIO, &nb);
+
+    ctx.socket = s;
+
+    ikcpcb *kcp;
+
+    kcp = ikcp_create(ctx.channel, &ctx);
+    if (kcp == NULL) return 1;
+
+    ikcp_setoutput(kcp, kcp_output);
+    ikcp_nodelay(kcp, 1, 1, 2, 1);
+    ikcp_wndsize(kcp, 1024, 1024);
+
+    IUINT32 current = iclock();
+    IUINT32 slap    = current + 20;
+    IUINT32 index   = 0;
+    IUINT32 next    = 0;
+    ssize_t n;
+    char    buffer[65536];
+
+    printf("inited\n");
+
+    while (1)
+    {
+        isleep(1);
+        current = iclock();
+        ikcp_update(kcp, iclock());
+
+        // 处理底层数据
+        while (1)
+        {
+            bzero(&ctx.peer_sa.sin_addr, sizeof(ctx.peer_sa.sin_addr));
+            ctx.peer_len = sizeof(ctx.peer_sa);
+
+            n = recvfrom(s, buffer, sizeof(buffer), 0,
+                         (struct sockaddr *)&ctx.peer_sa, &ctx.peer_len);
+            if (n < 0)
+            {
+                if (errno != EAGAIN)
+                {
+                    printf("recvfrom error: %d\n", n);
+                    return 1;
+                }
+
+                break;
+            }
+
+            char ip[INET_ADDRSTRLEN] = {0};
+            inet_ntop(ctx.peer_sa.sin_family, &ctx.peer_sa.sin_addr, ip,
+                      INET_ADDRSTRLEN);
+
+            printf("recv: %d bytes from %s:%d\n", n, ip,
+                   ntohs(ctx.peer_sa.sin_port));
+
+            ikcp_input(kcp, buffer, n);
+        }
+
+        // kcp回显数据
+        while (1)
+        {
+            n = ikcp_recv(kcp, buffer, 10);
+
+            // 没有收到包就退出
+            if (n < 0)
+            {
+                break;
+            }
+
+            ikcp_send(kcp, buffer, n);
+        }
+    }
+
+    ikcp_release(kcp);
+
+    return 0;
+}


### PR DESCRIPTION
1. 掩码的16进制相对于10进制来说，可读性更强。
2. 增加一个打开所有日志的宏，方便集成kcp的人快速打开所有日志。