### PR TITLE
improve CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,23 +1,15 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
 
-if(DEFINED PROJECT_NAME)
-    set(KCP_IS_TOP_PROJECT OFF)
-else()
-    set(KCP_IS_TOP_PROJECT ON)
-endif()
-
 project(kcp LANGUAGES C)
+
+include(CTest)
+include(GNUInstallDirs)
 
 cmake_policy(SET CMP0054 NEW)
 
-option(KCP_BUILD_SHARED_LIBS "Build KCP as a shared lib" OFF)
-option(KCP_BUILD_INSTALL "Build install target" ${KCP_IS_TOP_PROJECT})
-option(KCP_BUILD_TESTS "Build tests" ${KCP_IS_TOP_PROJECT})
-
-if(KCP_BUILD_SHARED_LIBS)
-    if(WIN32)
-        set(exports_def_file "${CMAKE_CURRENT_BINARY_DIR}/exports.def")
-        set(exports_def_contents
+if(BUILD_SHARED_LIBS AND WIN32)
+    set(exports_def_file "${CMAKE_CURRENT_BINARY_DIR}/exports.def")
+    set(exports_def_contents
 "EXPORTS 
     ikcp_create
     ikcp_release
@@ -38,39 +30,31 @@ if(KCP_BUILD_SHARED_LIBS)
     ikcp_getconv
 ")
 
-        file(WRITE "${exports_def_file}" "${exports_def_contents}")
-        add_library(kcp SHARED ikcp.h ikcp.c "${exports_def_file}")
-    else()
-        add_library(kcp SHARED ikcp.h ikcp.c)
-    endif()
+    file(WRITE "${exports_def_file}" "${exports_def_contents}")
+    add_library(kcp ikcp.c "${exports_def_file}")
 else()
-    add_library(kcp STATIC ikcp.h ikcp.c)
+    add_library(kcp ikcp.c)
 endif()
 
-if(KCP_BUILD_INSTALL)
-    include(GNUInstallDirs)
+install(FILES ikcp.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
-    set_target_properties(kcp PROPERTIES PUBLIC_HEADER ikcp.h)
+install(TARGETS kcp
+    EXPORT kcp-targets
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)
 
-    install(TARGETS kcp
-        EXPORT kcp-targets
-        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
-        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-    )
+install(EXPORT kcp-targets
+    FILE kcp-config.cmake
+    NAMESPACE kcp::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/kcp
+)
 
-    install(EXPORT kcp-targets
-        FILE kcp-config.cmake
-        NAMESPACE kcp::
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/kcp
-    )
-endif()
-
-if(KCP_BUILD_TESTS)
+if(BUILD_TESTING)
     enable_language(CXX)
-    
+
     add_executable(kcp_test test.cpp)
     if(MSVC AND NOT (MSVC_VERSION LESS 1900))
         target_compile_options(kcp_test PRIVATE /utf-8)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,34 +1,78 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
+
+if(DEFINED PROJECT_NAME)
+    set(KCP_IS_TOP_PROJECT OFF)
+else()
+    set(KCP_IS_TOP_PROJECT ON)
+endif()
 
 project(kcp LANGUAGES C)
 
-include(CTest)
-include(GNUInstallDirs)
+cmake_policy(SET CMP0054 NEW)
 
-add_library(kcp STATIC ikcp.c)
-add_library(kcp_shared SHARED ikcp.c)
+option(KCP_BUILD_SHARED_LIBS "Build KCP as a shared lib" OFF)
+option(KCP_BUILD_INSTALL "Build install target" ${KCP_IS_TOP_PROJECT})
+option(KCP_BUILD_TESTS "Build tests" ${KCP_IS_TOP_PROJECT})
 
-set_property(TARGET kcp_shared PROPERTY LIBRARY_OUTPUT_NAME kcp)
+if(KCP_BUILD_SHARED_LIBS)
+    if(WIN32)
+        set(exports_def_file "${CMAKE_CURRENT_BINARY_DIR}/exports.def")
+        set(exports_def_contents
+"EXPORTS 
+    ikcp_create
+    ikcp_release
+    ikcp_setoutput
+    ikcp_recv
+    ikcp_send
+    ikcp_update
+    ikcp_check
+    ikcp_input
+    ikcp_flush
+    ikcp_peeksize
+    ikcp_setmtu
+    ikcp_wndsize
+    ikcp_waitsnd
+    ikcp_nodelay
+    ikcp_log
+    ikcp_allocator
+    ikcp_getconv
+")
 
-install(FILES ikcp.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+        file(WRITE "${exports_def_file}" "${exports_def_contents}")
+        add_library(kcp SHARED ikcp.h ikcp.c "${exports_def_file}")
+    else()
+        add_library(kcp SHARED ikcp.h ikcp.c)
+    endif()
+else()
+    add_library(kcp STATIC ikcp.h ikcp.c)
+endif()
 
-install(TARGETS kcp_shared
-    EXPORT kcp-targets
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
+if(KCP_BUILD_INSTALL)
+    include(GNUInstallDirs)
 
-install(EXPORT kcp-targets
-    FILE kcp-config.cmake
-    NAMESPACE kcp::
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/kcp
-)
+    set_target_properties(kcp PROPERTIES PUBLIC_HEADER ikcp.h)
 
-if (BUILD_TESTING)
+    install(TARGETS kcp
+        EXPORT kcp-targets
+        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+
+    install(EXPORT kcp-targets
+        FILE kcp-config.cmake
+        NAMESPACE kcp::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/kcp
+    )
+endif()
+
+if(KCP_BUILD_TESTS)
     enable_language(CXX)
     
     add_executable(kcp_test test.cpp)
     if(MSVC AND NOT (MSVC_VERSION LESS 1900))
         target_compile_options(kcp_test PRIVATE /utf-8)
     endif()
-endif ()
+endif()


### PR DESCRIPTION
本补丁是对 https://github.com/skywind3000/kcp/pull/376 的一个补充（考虑到 https://github.com/skywind3000/kcp/pull/376 在增加了动态库 install 的同时，未保留原来的静态库 install）。

- 将 CMake 最小版本需求从 2.6 升到了 2.8.12，以消除构建过程中的 deprecation warning；
- 新增三个选项，以给用户对构建过程更多控制：
  - KCP_BUILD_SHARED_LIBS：是否作为动态库构建，默认为 OFF，以与 BUILD_SHARED_LIBS 的默认保持一致；
  - KCP_BUILD_INSTALL：是否生成 install target；
  - KCP_BUILD_TESTS：是否构建测试项目；

  对于 KCP_BUILD_INSTALL、KCP_BUILD_TESTS：
  - 如果 KCP 是作为一个 Top project 来构建，则这两个开关项默认打开；
  - 如果 KCP 是作为一个子项目来构建（比如，通过 add_subdirectory），则这两个开关项默认关闭；
- 完善 Windows 平台动态库构建支持；

  在 Windows 平台上生成动态库要么需要通过 __declspec(dllexport) 来修饰要导出的函数符号，要么需要通过一个 [DEF 文件](https://learn.microsoft.com/en-us/cpp/build/exporting-from-a-dll-using-def-files?view=msvc-170) 来声明所有要导出的符号。使用前一种方案可能需要在 ikcp.h 中加一段宏定义，所以我这里选择了使用一个 DEF 文件来声明所有要导出的符号。

- 完善 Windows 平台动态库的 install；

本补丁与 https://github.com/skywind3000/kcp/pull/376 不兼容的部分：

- 不再同时构建静态库与动态库，而是让用户能够在二者之间选择其一；

可以进一步完善的地方：

目前，我是直接在 CMakeLists.txt 里将导出的符号信息写入到一个临时的 exports.def 中的。如果用户不使用 CMake（比如：用户用 nmake），为了给予其方便，可考虑将 exports.def 提交到代码库里。
