### PR TITLE
add: `kcp.py` to readme

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -177,6 +177,7 @@ Both the use and configuration of the protocol is very simple, in most cases, af
 - [xkcptun](https://github.com/liudf0716/xkcptun): C language implementation of kcptun, embedded-friendly for [LEDE](https://github.com/lede-project/source) and [OpenWrt](https://github.com/openwrt/openwrt) projects.
 - [yasio](https://github.com/yasio/yasio): A cross-platform asynchronous socket library focus on any client application with kcp support, easy to use, API same with UDP and TCP, see [benchmark-pump](https://github.com/yasio/yasio/blob/master/benchmark.md).
 - [gouxp](https://github.com/shaoyuan1943/gouxp): Implementing a callback-based KCP development package with Go, with decryption and FEC support, is easy to use.
+- [kcp.py](https://github.com/RealistikDash/kcp.py): Python bindings and networking with an emphasis on dev friendliness.
 
 # Protocol Comparison
 


### PR DESCRIPTION
Added a Python project for the protocol. Missing a Chinese translation (hence a draft PR).

Also normalised line endings in the readme.