### PR TITLE
快速重传的limit单独计数

### DIFF
--- a/ikcp.c
+++ b/ikcp.c
@@ -1046,6 +1046,7 @@ void ikcp_flush(ikcpcb *kcp)
 		newseg->rto = kcp->rx_rto;
 		newseg->fastack = 0;
 		newseg->xmit = 0;
+		newseg->fast_xmit = 0;
 	}
 
 	// calculate resent
@@ -1077,10 +1078,11 @@ void ikcp_flush(ikcpcb *kcp)
 			lost = 1;
 		}
 		else if (segment->fastack >= resent) {
-			if ((int)segment->xmit <= kcp->fastlimit || 
+			if ((int)segment->fast_xmit < kcp->fastlimit || 
 				kcp->fastlimit <= 0) {
 				needsend = 1;
 				segment->xmit++;
+				segment->fast_xmit++;
 				segment->fastack = 0;
 				segment->resendts = current + segment->rto;
 				change++;

--- a/ikcp.h
+++ b/ikcp.h
@@ -279,6 +279,7 @@ struct IKCPSEG
 	IUINT32 rto;
 	IUINT32 fastack;
 	IUINT32 xmit;
+	IUINT32 fast_xmit;
 	char data[1];
 };
 


### PR DESCRIPTION
因为这里的目的是防止流量激增，但是当网络恢复时，可能已经经过了几次超时重传，这里反而会限制恢复速度。