### PR TITLE
Make it possible to set IKCP_WND_RCV > 256

### DIFF
--- a/ikcp.c
+++ b/ikcp.c
@@ -456,10 +456,10 @@ int ikcp_peeksize(const ikcpcb *kcp)
 	for (p = kcp->rcv_queue.next; p != &kcp->rcv_queue; p = p->next) {
 		seg = iqueue_entry(p, IKCPSEG, node);
 		length += seg->len;
-		if (seg->frg == 0) break;
+		if (seg->frg == 0) return length;
 	}
 
-	return length;
+	return -1;
 }
 
 
@@ -529,7 +529,7 @@ int ikcp_send(ikcpcb *kcp, const char *buffer, int len)
 			memcpy(seg->data, buffer, size);
 		}
 		seg->len = size;
-		seg->frg = (kcp->stream == 0)? (count - i - 1) : 0;
+		seg->frg = (kcp->stream == 0)? _imin_(count - i - 1, 255) : 0;
 		iqueue_init(&seg->node);
 		iqueue_add_tail(&seg->node, &kcp->snd_queue);
 		kcp->nsnd_que++;


### PR DESCRIPTION
虽然KCP大部分情况下应该只用于长度较小的网络协议包，但少数情况下还是会有发大包的需求（比如游戏登录时个别玩家要同步的数据太多）。

为了处理这种情况，需要：
1. 改大IKCP_WND_RCV
2. 修改部分frg相关逻辑，处理分片数量>256的情况

这个PR不修改协议格式，仅修改2处frg逻辑，让KCP可以支持设置IKCP_WND_RCV>256的值，且不影响IKCP_WND_RCV<=256时的逻辑。

ps. 分片数量>256时需要遍历rcv_queue找第一个frg==0的分片，如果大包频率太高会有性能下降。